### PR TITLE
Add gitpod preview comments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,3 +15,9 @@ vscode:
   extensions:
     - esbenp.prettier-vscode@5.1.0:M3Ww4EayZWhGCgk49C1Ldw==
     - dbaeumer.vscode-eslint@2.1.3:1NRvj3UKNTNwmYjptmUmIw==
+
+github:
+  prebuilds:
+    pullRequests: true
+    pullRequestsFromForks: true
+    addComment: true


### PR DESCRIPTION
This PR adds support for Gitpod preview comments.

(These configs were ported from the `discord-bot-test` repo and for that credit goes to Brad)
