### PR TITLE
Add User model, sample data, and tests

### DIFF
--- a/sample-data/sampleUserData.json
+++ b/sample-data/sampleUserData.json
@@ -1,0 +1,5 @@
+{
+  "email": "johnny123@example.com",
+  "password": "foobar123",
+  "userName": "John Doe"
+}

--- a/src/models/db/user.js
+++ b/src/models/db/user.js
@@ -1,0 +1,5 @@
+const { model } = require('mongoose');
+
+const userSchema = require('../../schemas/db/userSchema');
+
+module.exports = model('User', userSchema);

--- a/src/models/db/user.js
+++ b/src/models/db/user.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { model } = require('mongoose');
 
 const userSchema = require('../../schemas/db/userSchema');

--- a/src/schemas/db/userSchema.js
+++ b/src/schemas/db/userSchema.js
@@ -33,7 +33,8 @@ const userSchema = new Schema(
     },
 
     refreshToken: {
-      type: String
+      type: String,
+      required: false
     },
 
     userName: {

--- a/src/schemas/db/userSchema.js
+++ b/src/schemas/db/userSchema.js
@@ -1,0 +1,46 @@
+/**
+ * @file userSchema.js - Mongoose schema for users.
+ */
+const { Schema } = require('mongoose');
+const { ObjectID } = Schema.Types;
+
+const userSchema = new Schema(
+  {
+    email: {
+      type: String,
+      required: true
+    },
+
+    password: {
+      type: String,
+      required: true
+    },
+
+    linkedCompanyId: {
+      type: ObjectID
+    },
+
+    permissions: {
+      read: {
+        type: Boolean,
+        default: false
+      },
+      write: {
+        type: Boolean,
+        default: false
+      }
+    },
+
+    refreshToken: {
+      type: String
+    },
+
+    userName: {
+      type: String,
+      required: true
+    }
+  },
+  { timestamps: true }
+);
+
+module.exports = userSchema;

--- a/src/schemas/db/userSchema.js
+++ b/src/schemas/db/userSchema.js
@@ -1,6 +1,8 @@
 /**
  * @file userSchema.js - Mongoose schema for users.
  */
+'use strict';
+
 const { Schema } = require('mongoose');
 const { ObjectID } = Schema.Types;
 

--- a/src/schemas/db/userSchema.js
+++ b/src/schemas/db/userSchema.js
@@ -17,7 +17,8 @@ const userSchema = new Schema(
     },
 
     linkedCompanyId: {
-      type: ObjectID
+      type: ObjectID,
+      required: false
     },
 
     permissions: {

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -1,0 +1,83 @@
+const mongoose = require('mongoose');
+const User = require('../src/models/db/user');
+const sampleUserData = require('../sample-data/sampleUserData.json');
+
+const {
+  Error: { ValidationError }
+} = mongoose;
+
+const validUserData = {
+  ...sampleUserData
+};
+
+describe('User data validation', () => {
+  it('should accept valid user data', async () => {
+    const validUser = new User(validUserData);
+
+    await expect(validUser.validate()).resolves.toBeUndefined();
+  });
+
+  it.each(['email', 'password', 'userName'])(
+    'should reject user data which has no `%s` field',
+    async (field) => {
+      const incompleteUserData = {
+        ...validUserData,
+        ...{ [field]: undefined }
+      };
+      const incompleteUser = new User(incompleteUserData);
+
+      await expect(incompleteUser.validate()).rejects.toThrow(ValidationError);
+    }
+  );
+});
+
+describe('User data persistence', () => {
+  beforeAll(() =>
+    mongoose.connect(process.env.MONGO_URL, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true
+    })
+  );
+
+  it('should include the value of every schema-defined field', async () => {
+    expect.hasAssertions();
+    const user = new User(validUserData);
+
+    await user.save();
+
+    const savedUser = await User.findOne({ _id: user._id });
+
+    // Checks if the provided fields are unchanged.
+    expect(savedUser.email).toBe(user.email);
+    expect(savedUser.password).toBe(user.password);
+    expect(savedUser.userName).toBe(user.userName);
+  });
+
+  it('should not include extra fields', async () => {
+    expect.hasAssertions();
+    const userDataWithExtraInfo = {
+      ...validUserData,
+      extraInfo: 'Extra info placeholder'
+    };
+    const userWithExtraInfo = new User(userDataWithExtraInfo);
+
+    await userWithExtraInfo.save();
+
+    const savedUser = await User.findOne({ _id: userWithExtraInfo._id });
+
+    expect(savedUser).toBeTruthy();
+    expect(savedUser.extraInfo).toBeUndefined();
+  });
+
+  it('should include the `createdAt` and `updatedAt` fields', async () => {
+    expect.hasAssertions();
+    const validUser = new User(validUserData);
+
+    const savedUser = await validUser.save();
+
+    expect(savedUser.createdAt).toBeDefined();
+    expect(savedUser.updatedAt).toBeDefined();
+  });
+
+  afterAll(() => mongoose.connection.close());
+});

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const mongoose = require('mongoose');
 
 const User = require('../src/models/db/user');

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const User = require('../src/models/db/user');
 const sampleUserData = require('../sample-data/sampleUserData.json');
 
-const validUserData = JSON.parse(JSON.stringify(sampleUserData));
+const validUserData = { ...sampleUserData };
 
 describe('User data validation', () => {
   it('should accept valid user data', async () => {

--- a/tests/userModel.test.js
+++ b/tests/userModel.test.js
@@ -1,14 +1,9 @@
 const mongoose = require('mongoose');
+
 const User = require('../src/models/db/user');
 const sampleUserData = require('../sample-data/sampleUserData.json');
 
-const {
-  Error: { ValidationError }
-} = mongoose;
-
-const validUserData = {
-  ...sampleUserData
-};
+const validUserData = JSON.parse(JSON.stringify(sampleUserData));
 
 describe('User data validation', () => {
   it('should accept valid user data', async () => {
@@ -26,7 +21,9 @@ describe('User data validation', () => {
       };
       const incompleteUser = new User(incompleteUserData);
 
-      await expect(incompleteUser.validate()).rejects.toThrow(ValidationError);
+      await expect(incompleteUser.validate()).rejects.toThrow(
+        mongoose.Error.ValidationError
+      );
     }
   );
 });


### PR DESCRIPTION
**Description**

This changeset includes three new files, namely;

- Some minimal sample user data in sampleUserData.js. It has values only for required fields.
- The associated Mongoose schema and model.
  Currently it defines a simple string `password` field so as to minimize merge conflicts with the coming auth implementation, but of course it will have to be redefined as a strongly encrypted password as soon as possible.
- A corresponding Jest test file.
I've given my own style to this file since I wanted to experiment a bit with Jest, so it is currently inconsistent with respect to the other test files. But it shouldn't be difficult to modify it to match the other files if needed.
