### PR TITLE
Implement a password encryption utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/Twaha-Rahman/e-commercify#readme",
   "dependencies": {
     "argparse": "^1.0.10",
+    "bcrypt-pbkdf": "^1.0.2",
     "chalk": "^4.1.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/sample.env
+++ b/sample.env
@@ -13,3 +13,7 @@ MONGO_URL=mongodb://127.0.0.1/e-commercify
 AMOUNT_OF_SAMPLE_PRODUCT_DATA=100
 AMOUNT_OF_SAMPLE_BANNER_DATA=5
 AMOUNT_OF_SAMPLE_REVIEW_DATA=5
+
+## Variables used for password encryption
+
+SALT=verysaltyindeed

--- a/src/modules/encrypt-password.js
+++ b/src/modules/encrypt-password.js
@@ -1,0 +1,63 @@
+/**
+ * @file encrypt-password.js - Simple password encryption function using
+ *   bcrypt-pbkdf.
+ */
+'use strict';
+
+const { pbkdf } = require('bcrypt-pbkdf');
+
+const { SALT } = process.env;
+
+(function validateSaltVariable() {
+  const minSaltLengh = 12;
+
+  if (typeof SALT !== 'string' || SALT.length < minSaltLengh) {
+    throw new TypeError(
+      // eslint-disable-next-line max-len
+      `The SALT environment variable must be at least ${minSaltLengh} characters long.`
+    );
+  }
+})();
+
+/**
+ * Encrypts a password using bcrypt.
+ *
+ * - The salt is extracted from the SALT environment variable.
+ *
+ * - For security this function does not return a string but a mutable buffer,
+ *   so that you can immediately clear it after use by doing `buffer.fill(0)`.
+ *
+ * @param {string} password
+ * @param {number} [outputLength] - The length the generated output should be.
+ * @param {number} [numberOfRounds] - The number of rounds of the PBKDF
+ *   encryption algorithm to perform.
+ * @returns {Buffer}
+ */
+function encryptPassword(password, outputLength = 32, numberOfRounds = 1) {
+  if (typeof password !== 'string') {
+    throw new TypeError('Argument `password` must be a string.');
+  }
+
+  const buffer = Buffer.from(password);
+  /*
+   * Note that `buffer.length` is not the same as `password.length` since
+   *   passwords may contain non-ASCII characters.
+   */
+  const bufferLength = buffer.length;
+  const saltBuffer = Buffer.from(SALT);
+  const saltBufferLength = saltBuffer.length;
+  const outputBuffer = Buffer.alloc(outputLength);
+
+  pbkdf(
+    buffer,
+    bufferLength,
+    saltBuffer,
+    saltBufferLength,
+    outputBuffer,
+    outputLength,
+    numberOfRounds
+  );
+  return outputBuffer;
+}
+
+module.exports = encryptPassword;


### PR DESCRIPTION
**Description**

This is a simple but convenient password encryption function using bcrypt-pbkdf.

- add SALT environment variable;
- add bcrypt-pbkcd ^1.0.2 as dependency.

**Additional Information**

Some tests and parameter tuning might be needed, but it should already be functional enough to serve as a basis for password encryption
